### PR TITLE
BottomSheet would overlap system navigation.

### DIFF
--- a/app/src/main/java/dev/zezula/books/ui/screen/list/BookListScreen.kt
+++ b/app/src/main/java/dev/zezula/books/ui/screen/list/BookListScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.material.icons.filled.Menu
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.BottomAppBar
-import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.DrawerState
 import androidx.compose.material3.DrawerValue
@@ -281,7 +280,6 @@ private fun AddBookBottomSheet(
     ModalBottomSheet(
         onDismissRequest = { onAddBookSheetCloseRequested() },
         sheetState = bottomSheetState,
-        windowInsets = BottomSheetDefaults.windowInsets,
     ) {
         Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.Center) {
             Text(stringResource(R.string.home_btn_add_book), style = MaterialTheme.typography.titleMedium)
@@ -289,7 +287,8 @@ private fun AddBookBottomSheet(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(top = 16.dp),
+                .padding(top = 16.dp)
+                .padding(bottom = 54.dp),
         ) {
             ListItem(
                 modifier = Modifier


### PR DESCRIPTION
Looks like this is bug in material3 (https://stackoverflow.com/questions/76245357/how-to-prevent-modalbottomsheet-from-overlapping-with-the-system-buttons)